### PR TITLE
add tests for loading existing organization into OrgTiger object

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+moto

--- a/test/test_orgtiger.py
+++ b/test/test_orgtiger.py
@@ -1,4 +1,16 @@
 import pytest
+from moto import (
+    mock_organizations,
+    mock_sts,
+    mock_iam,
+)
+
+from orgcrawler import crawlers, orgs, utils
+from orgcrawler.mock.org import (
+    MockOrganization,
+    ORG_ACCESS_ROLE,
+    MASTER_ACCOUNT_ID,
+)
 from  orgtiger.tiger import OrgTiger
 
 
@@ -7,3 +19,21 @@ def test_makes_orgtiger_instance():
     assert isinstance(my_orgtiger, OrgTiger)
     
 
+@mock_sts
+@mock_organizations
+def test_orgtiger_has_org_attribute():
+    my_orgtiger = OrgTiger(name='moch_org', org_access_role=ORG_ACCESS_ROLE, master_account_id=MASTER_ACCOUNT_ID)
+    assert my_orgtiger.name == 'moch_org'
+    assert isinstance(my_orgtiger.org, orgcrawler.orgs.Org)
+
+@mock_sts
+@mock_organizations
+def test_orgtiger_loads_an_existing_org():
+    MockOrganization().simple()
+    my_orgtiger = OrgTiger(name='moch_org', org_access_role=ORG_ACCESS_ROLE, master_account_id=MASTER_ACCOUNT_ID)
+    my_orgtiger.org.load()
+    assert my_orgtiger.org.id is not None
+    assert my_orgtiger.org.root_id is not None
+    assert len(org.accounts) > 0
+    assert len(org.org_units) > 0
+    assert len(org.policies) > 0


### PR DESCRIPTION
Resolves #11 

def test_orgtiger_has_org_attribute():
def test_orgtiger_loads_an_existing_org():

tests are failing