### PR TITLE
Issue17 initialize spec dir

### DIFF
--- a/orgtiger/spec.py
+++ b/orgtiger/spec.py
@@ -1,0 +1,17 @@
+import os
+
+
+DEFAULT_SPEC_DIR = "~/.local/orgtiger/spec.d"
+
+
+class Spec(object):
+
+    def __init__(self, spec_dir=DEFAULT_SPEC_DIR):
+        self.spec_dir = spec_dir = os.path.expanduser(spec_dir)
+
+    def validate_spec_dir(self):
+        os.makedirs(self.spec_dir, exist_ok=True)
+
+
+
+

--- a/orgtiger/spec.py
+++ b/orgtiger/spec.py
@@ -1,4 +1,9 @@
 import os
+import sys
+import logging
+
+import git
+from git.exc import InvalidGitRepositoryError
 
 
 DEFAULT_SPEC_DIR = "~/.local/orgtiger/spec.d"
@@ -8,9 +13,24 @@ class Spec(object):
 
     def __init__(self, spec_dir=DEFAULT_SPEC_DIR):
         self.spec_dir = spec_dir = os.path.expanduser(spec_dir)
+        #self.log = logging.Logger(__name__)
 
-    def validate_spec_dir(self):
+    def validate(self):
+        if not os.path.isdir(self.spec_dir):
+            #self.log.error("Spec dir does not exist.  Try running Spec.generate()")
+            sys.exit("Spec dir does not exist.  Try running Spec.generate()")
+        try:
+            self.repo = git.Repo(self.spec_dir)
+        except InvalidGitRepositoryError as e:
+            sys.exit("Spec dir is not a git repo.  Try running Spec.generate()")
+
+    def generate(self):
         os.makedirs(self.spec_dir, exist_ok=True)
+        #self.repo = git.Repo(self.spec_dir)
+        #try:
+        #    self.repo = git.Repo(self.spec_dir)
+        #except:
+        #    pass
 
 
 

--- a/orgtiger/spec.py
+++ b/orgtiger/spec.py
@@ -10,6 +10,11 @@ from git.exc import InvalidGitRepositoryError, NoSuchPathError
 
 DEFAULT_SPEC_DIR = "~/.local/orgtiger/spec.d"
 
+class SPEC_VALIDATION_ERROR(Exception):
+    """Base class for spec validation errors"""
+
+class SPEC_GENERATION_ERROR(Exception):
+    """Base class for spec generation errors"""
 
 class Spec(object):
 
@@ -28,7 +33,7 @@ class Spec(object):
         except NoSuchPathError as e:
             logmsg['MESSAGE'] = "Spec dir '{}' does not exist.  Try running Spec.generate()".format(self.spec_dir)
             self.log.critical(logmsg)
-            sys.exit(1)
+            raise SPEC_VALIDATION_ERROR('Spec dir does not exist')
         except InvalidGitRepositoryError as e:
             logmsg['MESSAGE'] = "Spec dir {} is not a git repo.  Try running Spec.generate()".format(self.spec_dir)
             self.log.error(logmsg)
@@ -41,12 +46,34 @@ class Spec(object):
         
 
     def generate(self):
-        os.makedirs(self.spec_dir, exist_ok=True)
-        #self.repo = git.Repo(self.spec_dir)
-        #try:
-        #    self.repo = git.Repo(self.spec_dir)
-        #except:
-        #    pass
+        logmsg = {
+            'FILE': __file__.split('/')[-1],
+            'CLASS': self.__class__.__name__,
+            'METHOD': inspect.stack()[0][3],
+        }
+        try:
+            self.repo = Repo(self.spec_dir)
+        except NoSuchPathError as e:
+            logmsg['MESSAGE'] = "Creating spec dir '{}'".format(self.spec_dir)
+            self.log.info(logmsg)
+            os.makedirs(self.spec_dir)
+            self._init_new_repo()
+        except InvalidGitRepositoryError as e:
+            if os.path.isdir(self.spec_dir) and not os.listdir(self.spec_dir):
+                self._init_new_repo()
+            else:
+                logmsg['MESSAGE'] = "Cannot initialize git repo in spec dir '{}'".format(self.spec_dir)
+                self.log.critical(logmsg)
+                raise SPEC_GENERATION_ERROR('Cannot initialize git repo')
+
+    def _init_new_repo(self):
+        self.repo = Repo.init(self.spec_dir)
+        with open(os.path.join(self.spec_dir, 'README.rst'), mode='a') as f:
+            f.write('Orgtiger Spec Files')
+            f.write('===================')
+        self.repo.index.add(os.path.join(self.spec_dir, 'README.rst'))
+        self.repo.index.commit('initial commit')
+
 
 
 

--- a/orgtiger/spec.py
+++ b/orgtiger/spec.py
@@ -61,10 +61,14 @@ class Spec(object):
         except InvalidGitRepositoryError as e:
             if os.path.isdir(self.spec_dir) and not os.listdir(self.spec_dir):
                 self._init_new_repo()
-            else:
-                logmsg['MESSAGE'] = "Cannot initialize git repo in spec dir '{}'".format(self.spec_dir)
+            elif os.path.isdir(self.spec_dir) and os.listdir(self.spec_dir):
+                logmsg['MESSAGE'] = "Cannot initialize git repo in spec dir. '{}' is not empty".format(self.spec_dir)
                 self.log.critical(logmsg)
-                raise SPEC_GENERATION_ERROR('Cannot initialize git repo')
+                raise SPEC_GENERATION_ERROR('proposed spec_dir is not empty')
+            elif os.path.isfile(self.spec_dir):
+                logmsg['MESSAGE'] = "Cannot initialize git repo in spec dir. '{}' is not a directory".format(self.spec_dir)
+                self.log.critical(logmsg)
+                raise SPEC_GENERATION_ERROR('proposed spec_dir is a file')
 
     def _init_new_repo(self):
         self.repo = Repo.init(self.spec_dir)

--- a/orgtiger/spec.py
+++ b/orgtiger/spec.py
@@ -1,9 +1,11 @@
 import os
 import sys
-import logging
+import inspect
+
+from orgcrawler.logger import Logger
 
 import git
-from git.exc import InvalidGitRepositoryError
+from git.exc import InvalidGitRepositoryError, NoSuchPathError
 
 
 DEFAULT_SPEC_DIR = "~/.local/orgtiger/spec.d"
@@ -13,16 +15,22 @@ class Spec(object):
 
     def __init__(self, spec_dir=DEFAULT_SPEC_DIR):
         self.spec_dir = spec_dir = os.path.expanduser(spec_dir)
-        #self.log = logging.Logger(__name__)
+        self.log = Logger()
 
     def validate(self):
-        if not os.path.isdir(self.spec_dir):
-            #self.log.error("Spec dir does not exist.  Try running Spec.generate()")
-            sys.exit("Spec dir does not exist.  Try running Spec.generate()")
+        logmsg = {
+            'FILE': __file__.split('/')[-1],
+            'CLASS': self.__class__.__name__,
+            'METHOD': inspect.stack()[0][3],
+        }
         try:
             self.repo = git.Repo(self.spec_dir)
+        except NoSuchPathError as e:
+            logmsg['ERROR'] = "Spec dir '{}' does not exist.  Try running Spec.generate()".format(self.spec_dir)
+            self.log.error(logmsg)
+            sys.exit(1)
         except InvalidGitRepositoryError as e:
-            sys.exit("Spec dir is not a git repo.  Try running Spec.generate()")
+            self.log.error("Spec dir {} is not a git repo.  Try running Spec.generate()", self.spec_dir)
 
     def generate(self):
         os.makedirs(self.spec_dir, exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# will eventually live in setup.py
+orgcrawler
+
+# testing
 pytest
 pytest-cov
 moto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 # will eventually live in setup.py
 orgcrawler
-
-# testing
-pytest
-pytest-cov
-moto
+GitPython

--- a/test/README.rst
+++ b/test/README.rst
@@ -7,7 +7,7 @@ Testing Setup
 ::
 
   pip install --upgrade pip
-  pip install -r requirements.txt
+  pip install -r test_requirements.txt
 
 
 Run Tests

--- a/test/test_orgtiger.py
+++ b/test/test_orgtiger.py
@@ -5,7 +5,7 @@ from moto import (
     mock_iam,
 )
 
-from orgcrawler import crawlers, orgs, utils
+from orgcrawler import orgs
 from orgcrawler.mock.org import (
     MockOrganization,
     ORG_ACCESS_ROLE,
@@ -24,7 +24,7 @@ def test_makes_orgtiger_instance():
 def test_orgtiger_has_org_attribute():
     my_orgtiger = OrgTiger(name='moch_org', org_access_role=ORG_ACCESS_ROLE, master_account_id=MASTER_ACCOUNT_ID)
     assert my_orgtiger.name == 'moch_org'
-    assert isinstance(my_orgtiger.org, orgcrawler.orgs.Org)
+    assert isinstance(my_orgtiger.org, orgs.Org)
 
 @mock_sts
 @mock_organizations
@@ -34,6 +34,6 @@ def test_orgtiger_loads_an_existing_org():
     my_orgtiger.org.load()
     assert my_orgtiger.org.id is not None
     assert my_orgtiger.org.root_id is not None
-    assert len(org.accounts) > 0
-    assert len(org.org_units) > 0
-    assert len(org.policies) > 0
+    assert len(my_orgtiger.org.accounts) > 0
+    assert len(my_orgtiger.org.org_units) > 0
+    assert len(my_orgtiger.org.policies) > 0

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -97,34 +97,6 @@ def test_generate_spec_dir(caplog):
     assert pytest_wrapped_e.type == SPEC_GENERATION_ERROR
     cleanup()
 
-    assert False
+    #assert False
 
 
-
-
-'''
-if no spec dir:
-  error: specdir not found.  provide hint about spec generator tool.
-  exit
-
-if spec dir, but not a git repo:
-  warn: spec dir not under version contoll
-
-if spec dir and git repo
-  info: report current branch, last commit date
-
-  if working tree is dirty
-    warn: uncommitted changes in spec dir
-'''
-
-'''
-using spec.generate()
-
-if specdir exists and is not empty:
-  error: specdir exists and is not empty
-  exit
-else:
-  attept to create spec dir. passive fail if exists  
-  initialize git repo
-
-'''

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import tempfile
 
@@ -18,12 +19,25 @@ def test_makes_spec_instance():
     assert isinstance(my_spec, Spec)
     assert my_spec.spec_dir == os.path.expanduser(DEFAULT_SPEC_DIR)
     
-def test_validate_spec_dir():
+# https://docs.pytest.org/en/stable/logging.html
+def test_validate_spec_dir(caplog):
     my_spec = Spec(spec_dir=os.path.join(TEST_SPEC_BASEDIR, 'spec.d'))
-    my_spec.validate()
-    assert os.path.isdir(my_spec.spec_dir)
-    assert isinstance(my_spec.repo, git.Repo)
-    print(TEST_SPEC_BASEDIR)
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        my_spec.validate()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1 
+
+    #print(caplog.record_tuples)
+    for record in caplog.records:
+        #print(record.levelname)
+        assert record.levelname == "ERROR"
+
+
+    #assert os.path.isdir(my_spec.spec_dir)
+    #assert isinstance(my_spec.repo, git.Repo)
+    #print(TEST_SPEC_BASEDIR)
+
+    #assert False
     cleanup()
 
 

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 
 import pytest
+import git
 
 from  orgtiger.spec import DEFAULT_SPEC_DIR, Spec 
 
@@ -17,16 +18,39 @@ def test_makes_spec_instance():
     assert isinstance(my_spec, Spec)
     assert my_spec.spec_dir == os.path.expanduser(DEFAULT_SPEC_DIR)
     
-def test_create_spec_dir():
+def test_validate_spec_dir():
     my_spec = Spec(spec_dir=os.path.join(TEST_SPEC_BASEDIR, 'spec.d'))
-    my_spec.validate_spec_dir()
+    my_spec.validate()
     assert os.path.isdir(my_spec.spec_dir)
+    assert isinstance(my_spec.repo, git.Repo)
     print(TEST_SPEC_BASEDIR)
     cleanup()
 
 
 
+'''
+if no spec dir:
+  error: specdir not found.  provide hint about spec generator tool.
+  exit
 
-#    checks that dir is a git repo working tree
-#    checks that we fail with error message if dir exists
+if spec dir, but not a git repo:
+  warn: spec dir not under version contoll
 
+if spec dir and git repo
+  info: report current branch, last commit date
+
+  if working tree is dirty
+    warn: uncommitted changes in spec dir
+'''
+
+'''
+using spec.generate()
+
+if specdir exists and is not empty:
+  error: specdir exists and is not empty
+  exit
+else:
+  attept to create spec dir. passive fail if exists  
+  initialize git repo
+
+'''

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -1,0 +1,32 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from  orgtiger.spec import DEFAULT_SPEC_DIR, Spec 
+
+
+TEST_SPEC_BASEDIR = tempfile.mkdtemp()
+
+def cleanup():
+    shutil.rmtree(TEST_SPEC_BASEDIR)
+
+def test_makes_spec_instance():
+    my_spec = Spec()
+    assert isinstance(my_spec, Spec)
+    assert my_spec.spec_dir == os.path.expanduser(DEFAULT_SPEC_DIR)
+    
+def test_create_spec_dir():
+    my_spec = Spec(spec_dir=os.path.join(TEST_SPEC_BASEDIR, 'spec.d'))
+    my_spec.validate_spec_dir()
+    assert os.path.isdir(my_spec.spec_dir)
+    print(TEST_SPEC_BASEDIR)
+    cleanup()
+
+
+
+
+#    checks that dir is a git repo working tree
+#    checks that we fail with error message if dir exists
+

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 
 import pytest
-import git
+from git import Repo
 
 from  orgtiger.spec import DEFAULT_SPEC_DIR, Spec 
 
@@ -13,32 +13,65 @@ TEST_SPEC_BASEDIR = tempfile.mkdtemp()
 
 def cleanup():
     shutil.rmtree(TEST_SPEC_BASEDIR)
+    #os.path.isdir(TEST_SPEC_BASEDIR)
 
 def test_makes_spec_instance():
     my_spec = Spec()
     assert isinstance(my_spec, Spec)
     assert my_spec.spec_dir == os.path.expanduser(DEFAULT_SPEC_DIR)
     
-# https://docs.pytest.org/en/stable/logging.html
 def test_validate_spec_dir(caplog):
+
+    # spec_dir does not exist
     my_spec = Spec(spec_dir=os.path.join(TEST_SPEC_BASEDIR, 'spec.d'))
+    assert not os.path.isdir(my_spec.spec_dir)
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         my_spec.validate()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1 
-
+    # https://docs.pytest.org/en/stable/logging.html
     #print(caplog.record_tuples)
     for record in caplog.records:
-        #print(record.levelname)
+        assert record.levelname == "CRITICAL"
+    caplog.clear()
+
+    # spec_dir exists, but not a git repo
+    os.makedirs(my_spec.spec_dir)
+    return_value = my_spec.validate()
+    assert not return_value
+    for record in caplog.records:
         assert record.levelname == "ERROR"
+    caplog.clear()
 
-
-    #assert os.path.isdir(my_spec.spec_dir)
-    #assert isinstance(my_spec.repo, git.Repo)
-    #print(TEST_SPEC_BASEDIR)
+    # repo exist, but has uncommited changes
+    with open(os.path.join(my_spec.spec_dir, 'emptyfile'), mode='w'): pass
+    temp_repo = Repo.init(my_spec.spec_dir)
+    temp_repo.index.add(os.path.join(my_spec.spec_dir, 'emptyfile'))
+    temp_repo.index.commit('initial commit')
+    with open(os.path.join(my_spec.spec_dir, 'emptyfile'), mode='a') as f:
+        f.write('testing 1 2 3 ')
+    return_value = my_spec.validate()
+    assert isinstance(my_spec.repo, Repo)
+    assert not return_value
+    for record in caplog.records:
+        assert record.levelname == "ERROR"
+    caplog.clear()
+  
+    # spec_dir working tree is clean
+    temp_repo.index.add(os.path.join(my_spec.spec_dir, 'emptyfile'))
+    temp_repo.index.commit('edit emptyfile')
+    return_value = my_spec.validate()
+    assert return_value
 
     #assert False
     cleanup()
+
+def test_generate_spec_dir(caplog):
+    #assert os.path.isdir(my_spec.spec_dir)
+    #assert isinstance(my_spec.repo, git.Repo)
+    #print(TEST_SPEC_BASEDIR)
+    return
+
 
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+# testing
+pytest
+pytest-cov
+moto


### PR DESCRIPTION
This PR Resolves #17 #18 #19 #20

initiliazes a new Spec object
generates Spec.spec_dir working tree
populates this with initial git repo
validates if this working tree is not a proper git repo or is dirty